### PR TITLE
Navigation and router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,25 @@
 import React, { Component } from "react";
+import { Router } from "@reach/router";
+import Loadable from "react-loadable";
+
+import { AppProvider } from "./AppProvider";
+import SiteHeader from "./components/SiteHeader";
+
+const AsyncOurStory = Loadable({
+  loader: () => import("./views/OurStory"),
+  loading: () => <span />
+});
 
 class App extends Component {
   render() {
-    return <div />;
+    return (
+      <AppProvider>
+        <SiteHeader />
+        <Router>
+          <AsyncOurStory path="/" />
+        </Router>
+      </AppProvider>
+    );
   }
 }
 

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -3,16 +3,12 @@ import React, { Component } from "react";
 export const AppContext = React.createContext();
 
 export class AppProvider extends Component {
-  handleIsBrandDark = bool => {
-    this.setState({
-      isBrandDark: bool
-    });
+  handleIsBrandDark = isBrandDark => {
+    this.setState({ isBrandDark });
   };
 
-  handleIsNavbarDark = bool => {
-    this.setState({
-      isNavbarDark: bool
-    });
+  handleIsNavbarDark = isNavbarDark => {
+    this.setState({ isNavbarDark });
   };
 
   state = {

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -1,0 +1,32 @@
+import React, { Component } from "react";
+
+export const AppContext = React.createContext();
+
+export class AppProvider extends Component {
+  handleIsBrandDark = bool => {
+    this.setState({
+      isBrandDark: bool
+    });
+  };
+
+  handleIsNavbarDark = bool => {
+    this.setState({
+      isNavbarDark: bool
+    });
+  };
+
+  state = {
+    isBrandDark: true,
+    isNavbarDark: true,
+    handleIsBrandDark: this.handleIsBrandDark,
+    handleIsNavbarDark: this.handleIsNavbarDark
+  };
+
+  render() {
+    return (
+      <AppContext.Provider value={this.state}>
+        {this.props.children}
+      </AppContext.Provider>
+    );
+  }
+}

--- a/src/components/Brand.js
+++ b/src/components/Brand.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { Link } from "@reach/router";
+import styled from "@emotion/styled";
+
+import { AppContext } from "../AppProvider";
+
+const StyledLink = styled(({ isBrandDark, ...props }) => <Link {...props} />)`
+  text-decoration: none;
+  color: ${props => (props.isBrandDark ? "#152540" : "white")};
+  font-size: 2rem;
+  font-family: Futura PT Demi;
+  font-weight: 600;
+  letter-spacing: 0.3125rem;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 0.6;
+  }
+`;
+
+const Brand = props => (
+  <StyledLink to="/" isBrandDark={props.isBrandDark}>
+    MEGAN & RINGO
+  </StyledLink>
+);
+
+export default props => (
+  <AppContext.Consumer>
+    {({ isBrandDark }) => <Brand {...props} isBrandDark={isBrandDark} />}
+  </AppContext.Consumer>
+);

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,105 @@
+import React, { Component } from "react";
+import { Link } from "@reach/router";
+import styled from "@emotion/styled";
+
+import { AppContext } from "../AppProvider";
+
+const StyledLink = styled(({ isNavbarDark, ...props }) => <Link {...props} />)`
+  text-decoration: none;
+  color: ${props => (props.isNavbarDark ? "#152540" : "white")};
+  font-size: 1.2rem;
+  font-weight: 500;
+  letter-spacing: 0.1875rem;
+  padding: 0.4em 0.8em;
+  transition: opacity 0.2s ease;
+
+  &:not(:last-child) {
+    margin-right: 0.8em;
+  }
+
+  &:hover {
+    opacity: 0.6;
+  }
+
+  &.active {
+    position: relative;
+  }
+
+  &.active::after {
+    position: absolute;
+    content: "";
+    border-bottom: 2px solid
+      ${props => (props.isNavbarDark ? "#152540" : "white")};
+    width: 40%;
+    left: 50%;
+    transform: translate3d(-50%, 0, 0);
+    bottom: -0.2em;
+  }
+`;
+
+class Navbar extends Component {
+  state = {
+    activeLink: ""
+  };
+
+  componentDidMount() {
+    this.setState({
+      activeLink: window.location.pathname
+    });
+  }
+
+  handleLinkClick = link => {
+    this.setState({
+      activeLink: link
+    });
+  };
+
+  render() {
+    const { activeLink } = this.state;
+
+    return (
+      <nav>
+        <ul>
+          <StyledLink
+            to="/"
+            className={activeLink === "/" ? "active" : ""}
+            onClick={() => this.handleLinkClick("/")}
+            isNavbarDark={this.props.isNavbarDark}
+          >
+            OUR STORY
+          </StyledLink>
+          <StyledLink
+            to="/when-where"
+            className={activeLink === "/when-where" ? "active" : ""}
+            onClick={() => this.handleLinkClick("/when-where")}
+            isNavbarDark={this.props.isNavbarDark}
+          >
+            WHEN & WHERE
+          </StyledLink>
+          <StyledLink
+            to="/album"
+            className={activeLink === "/album" ? "active" : ""}
+            onClick={() => this.handleLinkClick("/album")}
+            isNavbarDark={this.props.isNavbarDark}
+          >
+            ALBUM
+          </StyledLink>
+          <StyledLink
+            to="/rsvp"
+            className={activeLink === "/rsvp" ? "active" : ""}
+            onClick={() => this.handleLinkClick("/rsvp")}
+            isNavbarDark={this.props.isNavbarDark}
+          >
+            RSVP
+          </StyledLink>
+        </ul>
+      </nav>
+    );
+  }
+}
+
+export default props => (
+  <AppContext.Consumer>
+    {({ isNavbarDark }) => <Navbar {...props} isNavbarDark={isNavbarDark} />}
+  </AppContext.Consumer>
+);

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import Brand from "./Brand";
+import Navbar from "./Navbar";
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2em;
+  position: relative;
+  z-index: 1;
+`;
+
+const SiteHeader = () => (
+  <Header>
+    <Brand />
+    <Navbar />
+  </Header>
+);
+
+export default SiteHeader;

--- a/src/index.css
+++ b/src/index.css
@@ -358,6 +358,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   max-width: 1440px;
+  margin: 0 auto;
+  position: relative;
 }
 
 ol,

--- a/src/views/OurStory.js
+++ b/src/views/OurStory.js
@@ -1,0 +1,5 @@
+import React, { Fragment } from "react";
+
+const OurStory = () => <Fragment />;
+
+export default OurStory;


### PR DESCRIPTION
Created the `SiteHeader` which contains the `Brand` and `Navbar`. The routes are split with react-loadable. The color of the brand and navbar are handled with context. 

![navigation-router](https://user-images.githubusercontent.com/7979400/56940064-1fc61200-6ada-11e9-9a76-adf1e98b4bc7.png)
