### PR TITLE
Fixed mobile view for GuestInput and adjusted styles for form inputs

### DIFF
--- a/src/components/FormArea.js
+++ b/src/components/FormArea.js
@@ -50,8 +50,13 @@ const StyledLabel = styled.label`
 const StyledFormError = styled.span`
   color: rgba(255, 113, 113, 1);
   letter-spacing: 0.08em;
-  margin: 0 0 0 0.5em;
-  display: inline;
+  margin: 0.5em 0 0 0;
+  display: block;
+
+  @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
+    margin: 0 0 0 0.5em;
+    display: inline;
+  }
 
   @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) and (max-width: ${TABLET_LANDSCAPE_UP -
       1}px) {

--- a/src/components/GuestInput.js
+++ b/src/components/GuestInput.js
@@ -17,8 +17,7 @@ const [
 const StyledInputContainer = styled.div`
   margin-bottom: 0.67em;
   position: relative;
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
 
   ${props =>
     props.disabled &&
@@ -30,16 +29,34 @@ const StyledInputContainer = styled.div`
       bottom: 0;
       left: 0;
       right: 0;
-      font-size: 1.25rem;
       background-color: rgba(250, 252, 254, 1);
       border: 1px dashed rgba(220, 223, 226, 1);
       border-radius: 0.25em;
       text-align: center;
       color: rgba(54, 63, 84, 0.4);
       padding: 0 1em;
-      line-height: 2.7em;
+      display: flex;
+      justify-content: center;
+      align-items: center;
       transition: all 0.2s ease;
       cursor: not-allowed;
+      font-size: 1rem;
+
+      @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
+        font-size: 1.1rem;
+      }
+
+      @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
+        font-size: 1.15rem;
+      }
+
+      @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
+        font-size: 1.2rem;
+      }
+
+      @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
+        font-size: 1.25rem;
+      }
     }
 
     &:hover::after {
@@ -51,10 +68,11 @@ const StyledInputContainer = styled.div`
 const StyledLabel = styled.label`
   position: relative;
   margin-right: 0.5em;
+  width: 100%;
 `;
 
 const StyledGuestInput = styled.input`
-  display: inline-block;
+  font-family: Helvetica, "Futura PT", Arial, sans-serif;
   background-color: ${props =>
     props.error ? "rgba(255, 113, 113, 0.1)" : "rgba(250, 252, 254, 1)"};
   border: 1px solid
@@ -67,6 +85,7 @@ const StyledGuestInput = styled.input`
   vertical-align: middle;
   outline: none;
   opacity: ${props => (props.disabled ? "0" : "1")};
+  appearance: none;
   font-size: 1.1rem;
 
   @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
@@ -109,8 +128,7 @@ const StyledInputError = styled.span`
 const StyledAddButton = styled.button`
   outline: none;
   border: none;
-  font-family: "Futura PT";
-  display: inline-block;
+  font-family: "Futura PT", Helvetica, Arial, sans-serif;
   line-height: 1.25rem;
   letter-spacing: 0.15em;
   background-color: rgba(240, 240, 245, 1);

--- a/src/index.css
+++ b/src/index.css
@@ -342,7 +342,9 @@ summary,
 time,
 mark,
 audio,
-video {
+video,
+input,
+button {
   margin: 0;
   padding: 0;
   border: 0;

--- a/src/views/RSVP.js
+++ b/src/views/RSVP.js
@@ -182,6 +182,7 @@ const StyledNameFormArea = styled(FormArea)`
 `;
 
 const StyledFormInput = styled.input`
+  font-family: Helvetica, "Futura PT", Arial, sans-serif;
   display: block;
   height: 2.25em;
   width: 100%;
@@ -194,6 +195,7 @@ const StyledFormInput = styled.input`
     ${props =>
       props.error ? "rgba(255, 113, 113, 1)" : "rgba(220, 223, 226, 1)"};
   border-radius: 0.125em;
+  appearance: none;
   font-size: 1.1rem;
 
   @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
@@ -219,6 +221,7 @@ const StyledFormInput = styled.input`
 `;
 
 const StyledFormTextArea = styled.textarea`
+  font-family: Helvetica, "Futura PT", Arial, sans-serif;
   display: block;
   height: 8em;
   width: 100%;
@@ -229,6 +232,7 @@ const StyledFormTextArea = styled.textarea`
   resize: none;
   border: 1px solid rgba(220, 223, 226, 1);
   border-radius: 0.125em;
+  appearance: none;
   font-size: 1.1rem;
 
   @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {


### PR DESCRIPTION
The `GuestInput` now appears as expected in mobile, with the add button being on the same line as and to the right of the input. Previously, the add button would appear below the input. 

Removed the default input `appearance` seen in Safari mobile.

Added inputs and buttons to the css reset to remove Safari mobile's default padding and margin.

![mobile guest input](https://user-images.githubusercontent.com/7979400/62745589-aa8fa480-ba19-11e9-837e-f2da2331e8aa.png)

Added mobile responsive media queries for the div that appears after the user has reached the max number of guests.

![max guests](https://user-images.githubusercontent.com/7979400/62745590-ac596800-ba19-11e9-80c6-09c08d798353.png)
