### PR TITLE
Optimization for Our Story in Mobile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,8 +45,12 @@ const StyledParallaxContainer = styled.div`
 const StyledParallax = styled(
   ({ isOverflowY, parallaxBackground, ...props }) => <Parallax {...props} />
 )`
+  overflow: ${props =>
+    props.isOverflowY ? "visible" : "hidden scroll"} !important;
+
   & > div {
-    overflow-y: ${props => props.isOverflowY && "scroll !important"};
+    overflow: ${props => props.isOverflowY && "visible !important"};
+    height: ${props => props.isOverflowY && "100% !important"};
   }
 `;
 
@@ -140,6 +144,7 @@ const App = () => {
         ref={ref => (parallaxRef = ref)}
         pages={pages}
         isOverflowY={isOverflowY}
+        native
       >
         <AppProvider>
           <SiteHeader />
@@ -149,7 +154,7 @@ const App = () => {
                 unique
                 reset
                 // reset
-                // native
+                native={!isGreaterThanTablet}
                 items={location}
                 keys={location.pathname.split("/")[1]}
                 delay={300}


### PR DESCRIPTION
Added `native` prop to skip rendering on every single frame. There are many layers of animations occurring within the parallax scroll and on load, so this should alleviate the intensive computing by cutting down on the amount of rendering. This prop is only activated when the device is less than 768px in width to ensure the quality of the animation is preserved for devices that can support the rendering on every single frame.

Added override styles to ensure that the iOS bottom menu in Safari is hidden upon scrolling.