### PR TITLE
Added mobile responsive media queries for the site header and mobile menu

### DIFF
--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -20,6 +20,13 @@ export class AppProvider extends Component {
     navigationItems: [
       {
         id: shortid.generate(),
+        label: "Home",
+        desc: "Return to the homepage",
+        link: "/",
+        hidden: true
+      },
+      {
+        id: shortid.generate(),
         label: "Our Story",
         desc: "Read how it all began!",
         link: "/our-story"

--- a/src/components/Brand.js
+++ b/src/components/Brand.js
@@ -21,7 +21,7 @@ const [
 const StyledLink = styled(({ isBrandDark, ...props }) => <Link {...props} />)`
   text-decoration: none;
   color: ${props => (props.isBrandDark ? "#152540" : "white")};
-  font-family: "Futura PT Demi";
+  font-family: "Futura PT Demi", Helvetica, Arial, sans-serif;
   transition: opacity 0.2s ease;
   font-size: 1.25rem;
   letter-spacing: 0.1em;

--- a/src/components/Brand.js
+++ b/src/components/Brand.js
@@ -21,15 +21,15 @@ const [
 const StyledLink = styled(({ isBrandDark, ...props }) => <Link {...props} />)`
   text-decoration: none;
   color: ${props => (props.isBrandDark ? "#152540" : "white")};
-  ${"" /* font-size: 1.5rem; */}
-  font-family: Futura PT Demi;
-  font-weight: 600;
-  letter-spacing: 0.15em;
-  padding: 0.2em 1em;
+  font-family: "Futura PT Demi";
   transition: opacity 0.2s ease;
+  font-size: 1.25rem;
+  letter-spacing: 0.1em;
+  padding: 0.1em 0.5em;
 
   @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
-    font-size: 1.25rem;
+    letter-spacing: 0.15em;
+    padding: 0.2em 1em;
   }
 
   @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {

--- a/src/components/DropdownToggle.js
+++ b/src/components/DropdownToggle.js
@@ -3,17 +3,44 @@ import { Link } from "@reach/router";
 import styled from "@emotion/styled/macro";
 
 import { AppContext } from "../AppProvider";
+import { MIN_WIDTH_BREAKPOINTS } from "../enums";
+
+const [
+  ,
+  ,
+  ,
+  ,
+  ,
+  ,
+  ,
+  TABLET_PORTRAIT_UP,
+  TABLET_LANDSCAPE_UP,
+  DESKTOP_UP
+] = MIN_WIDTH_BREAKPOINTS;
 
 const StyledDropdownToggle = styled.span`
   color: ${props => (props.isNavbarDark ? "#152540" : "white")};
-  font-size: 1.4rem;
-  font-weight: 500;
-  letter-spacing: 0.1875rem;
+  font-size: 1rem;
   padding: 0.4em 0.8em;
   transition: opacity 0.2s ease;
   opacity: ${props => (props.active ? "1" : "0.8")};
   cursor: default;
   position: relative;
+  white-space: nowrap;
+  letter-spacing: 0.12rem;
+
+  @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
+    font-size: 1rem;
+    letter-spacing: 0.1875rem;
+  }
+
+  @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
+    font-size: 1.2rem;
+  }
+
+  @media only screen and (min-width: ${DESKTOP_UP}px) {
+    font-size: 1.4rem;
+  }
 
   &:not(:last-child) {
     margin-right: 1.3em;
@@ -72,7 +99,7 @@ const StyledDropdown = styled.div`
 `;
 
 const StyledDropdownLink = styled(({ ...props }) => <Link {...props} />)`
-  font-size: 1.2rem;
+  font-size: 0.875rem;
   display: block;
   width: 100%;
   text-align: center;
@@ -83,6 +110,14 @@ const StyledDropdownLink = styled(({ ...props }) => <Link {...props} />)`
   line-height: 2.4em;
   transition: opacity 0.2s ease;
   white-space: nowrap;
+
+  @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
+    font-size: 1rem;
+  }
+
+  @media only screen and (min-width: ${DESKTOP_UP}px) {
+    font-size: 1.2rem;
+  }
 
   &:hover {
     background-color: rgba(240, 240, 240, 1);

--- a/src/components/MobileMenu.js
+++ b/src/components/MobileMenu.js
@@ -1,9 +1,19 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { Link } from "@reach/router";
 import styled from "@emotion/styled/macro";
 import { animated, useSpring, config } from "react-spring";
 
 import { AppContext } from "../AppProvider";
+import { MIN_WIDTH_BREAKPOINTS } from "../enums";
+
+const [
+  ,
+  ,
+  POST_IPHONE6_PORTRAIT_UP,
+  POST_IPHONE6_PLUS_PORTRAIT_UP,
+  PHONE_LANDSCAPE_UP,
+  SMALL_DEVICES_LANDSCAPE_UP
+] = MIN_WIDTH_BREAKPOINTS;
 
 const StyledMobileMenu = styled("div")`
   width: 100vw;
@@ -14,20 +24,51 @@ const StyledMobileMenu = styled("div")`
   left: 0;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+  overflow-y: scroll;
+  padding-top: 4.25em;
+
+  @media only screen and (min-width: ${PHONE_LANDSCAPE_UP}px) {
+    padding-top: 5.25em;
+  }
 `;
 
 const NavList = styled("ul")`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  height: 100%;
-  max-width: 320px;
+  max-width: 10.75em;
+  padding-bottom: 3.25em;
+
+  @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
+    max-width: 12.75em;
+    padding-bottom: 4.25em;
+  }
+
+  @media only screen and (min-width: ${POST_IPHONE6_PLUS_PORTRAIT_UP}px) {
+    max-width: 14.75em;
+    padding-bottom: 5.25em;
+  }
+
+  @media only screen and (min-width: ${PHONE_LANDSCAPE_UP}px) {
+    max-width: 18.75em;
+    padding-bottom: 6.25em;
+  }
+
+  @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
+    max-width: 22.75em;
+    padding-bottom: 7.25em;
+  }
 `;
 
 const NavListItem = styled(animated.li)`
+  display: block;
   margin-bottom: 1.625em;
+
+  @media only screen and (min-width: ${PHONE_LANDSCAPE_UP}px) {
+    margin-bottom: 2em;
+  }
+
+  @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
+    margin-bottom: 2.625em;
+  }
 `;
 
 const StyledLink = styled(Link)`
@@ -36,21 +77,47 @@ const StyledLink = styled(Link)`
 
 const LinkLabel = styled("span")`
   font-weight: 700;
-  font-size: 2rem;
+  font-size: 1.4rem;
   line-height: 1.1875;
   color: #152540;
   display: block;
   text-transform: uppercase;
-  margin-bottom: 0.3em;
+  margin-bottom: 0.05em;
+
+  @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
+    font-size: 1.6rem;
+    margin-bottom: 0.1em;
+  }
+
+  @media only screen and (min-width: ${POST_IPHONE6_PLUS_PORTRAIT_UP}px) {
+    font-size: 1.8rem;
+    margin-bottom: 0.2em;
+  }
+
+  @media only screen and (min-width: ${PHONE_LANDSCAPE_UP}px) {
+    font-size: 2rem;
+  }
+
+  @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
+    font-size: 2.4rem;
+    margin-bottom: 0.2em;
+  }
 `;
 
 const LinkDesc = styled("span")`
   display: block;
-  font-weight: 400;
-  font-size: 1rem;
+  font-size: 0.875rem;
   line-height: 1.3;
   color: #657590;
   text-transform: uppercase;
+
+  @media only screen and (min-width: ${PHONE_LANDSCAPE_UP}px) {
+    font-size: 1rem;
+  }
+
+  @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
+    font-size: 1.25rem;
+  }
 `;
 
 const MobileMenu = ({ isToggled, navigationItems, onNavItemClick }) => {
@@ -63,6 +130,8 @@ const MobileMenu = ({ isToggled, navigationItems, onNavItemClick }) => {
       ),
     [navigationItems]
   );
+
+  let mobileMenuRef = null;
 
   const styles = memoizedNavigationItems.map((item, i) =>
     useSpring({
@@ -81,8 +150,15 @@ const MobileMenu = ({ isToggled, navigationItems, onNavItemClick }) => {
       immediate: !isToggled
     })
   );
+
+  useEffect(() => {
+    if (isToggled) {
+      mobileMenuRef.scrollTop = 0;
+    }
+  }, [isToggled]);
+
   return (
-    <StyledMobileMenu>
+    <StyledMobileMenu ref={ref => (mobileMenuRef = ref)}>
       <NavList>
         {memoizedNavigationItems.map(({ label, desc, link, id }, i) => (
           <NavListItem key={id} style={styles[i]}>

--- a/src/components/MobileNavbar.js
+++ b/src/components/MobileNavbar.js
@@ -54,22 +54,16 @@ const StyledCaret = styled.div`
   `}
 `;
 
-const MobileNavbar = () => {
-  const [isToggled, toggleMenu] = useState(false);
-
+const MobileNavbar = ({ isToggled, openMenu, closeMenu }) => {
   const { menuY } = useSpring({
     from: { menuY: 0 },
     menuY: isToggled ? 1 : 0,
     config: config.slow
   });
 
-  const closeMenu = () => {
-    toggleMenu(false);
-  };
-
   return (
     <Fragment>
-      <StyledMobileToggle onClick={() => toggleMenu(!isToggled)}>
+      <StyledMobileToggle onClick={isToggled ? closeMenu : openMenu}>
         <StyledHeartOutline
           className={isToggled ? "" : "no-fill"}
           isToggled={isToggled}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -21,21 +21,33 @@ const [
   DESKTOP_UP
 ] = MIN_WIDTH_BREAKPOINTS;
 
-const BTWN_TABLET_PORTRAIT_LANDSCAPE_UP = 896;
-
 const StyledNavbar = styled("nav")`
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
 `;
 
 const StyledNavList = styled("ul")`
   display: flex;
-  width: 100%;
-  justify-content: center;
 `;
 
 const StyledNavListItem = styled("li")`
   text-transform: uppercase;
+
+  &:not(:last-child) {
+    margin-right: 0.1em;
+
+    @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
+      margin-right: 0.7em;
+    }
+
+    @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
+      margin-right: 1em;
+    }
+
+    @media only screen and (min-width: ${DESKTOP_UP}px) {
+      margin-right: 1.3em;
+    }
+  }
 `;
 
 const StyledLink = styled(({ isNavbarDark, active, ...props }) => (
@@ -43,16 +55,27 @@ const StyledLink = styled(({ isNavbarDark, active, ...props }) => (
 ))`
   text-decoration: none;
   color: ${props => (props.isNavbarDark ? "#152540" : "white")};
-  font-size: 1.4rem;
-  font-weight: 500;
-  letter-spacing: 0.1875rem;
-  padding: 0.4em 0.8em;
+  font-size: 1rem;
+  padding: 0.2em 0.4em;
   transition: opacity 0.2s ease;
   opacity: ${props => (props.active ? "1" : "0.8")};
   position: relative;
+  white-space: nowrap;
+  letter-spacing: 0.12rem;
 
-  &:not(:last-child) {
-    margin-right: 1.3em;
+  @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
+    font-size: 1rem;
+    letter-spacing: 0.1875rem;
+  }
+
+  @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
+    font-size: 1.2rem;
+    padding: 0.3em 0.6em;
+  }
+
+  @media only screen and (min-width: ${DESKTOP_UP}px) {
+    font-size: 1.4rem;
+    padding: 0.4em 0.8em;
   }
 
   &:hover {
@@ -81,30 +104,32 @@ const Navbar = ({
 }) => (
   <StyledNavbar>
     <StyledNavList>
-      {navigationItems.map(item => (
-        <StyledNavListItem key={item.id}>
-          {item.dropdownItems ? (
-            <DropdownToggle
-              name={item.label}
-              items={item.dropdownItems}
-              handleLinkClick={handleLinkClick}
-              active={
-                item.dropdownItems.filter(dItem => dItem.link === activeLink)
-                  .length > 0
-              }
-            />
-          ) : (
-            <StyledLink
-              to={item.link}
-              onClick={() => handleLinkClick(item.link)}
-              isNavbarDark={isNavbarDark}
-              active={activeLink === item.link}
-            >
-              {item.label}
-            </StyledLink>
-          )}
-        </StyledNavListItem>
-      ))}
+      {navigationItems.map(item =>
+        !item.hidden ? (
+          <StyledNavListItem key={item.id}>
+            {item.dropdownItems ? (
+              <DropdownToggle
+                name={item.label}
+                items={item.dropdownItems}
+                handleLinkClick={handleLinkClick}
+                active={
+                  item.dropdownItems.filter(dItem => dItem.link === activeLink)
+                    .length > 0
+                }
+              />
+            ) : (
+              <StyledLink
+                to={item.link}
+                onClick={() => handleLinkClick(item.link)}
+                isNavbarDark={isNavbarDark}
+                active={activeLink === item.link}
+              >
+                {item.label}
+              </StyledLink>
+            )}
+          </StyledNavListItem>
+        ) : null
+      )}
     </StyledNavList>
   </StyledNavbar>
 );

--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -14,12 +14,11 @@ const [
   ,
   ,
   ,
-  PHONE_LANDSCAPE_UP,
   ,
   ,
+  BETWEEN_SMALL_DEVICES_TABLET_UP,
   TABLET_PORTRAIT_UP,
-  ,
-  DESKTOP_UP
+  TABLET_LANDSCAPE_UP
 ] = MIN_WIDTH_BREAKPOINTS;
 
 const AnimatedHeader = styled(
@@ -28,23 +27,25 @@ const AnimatedHeader = styled(
   )
 )`
   display: flex;
-  justify-content: ${props =>
-    props.isTabletPortraitUp ? "space-between" : "flex-end"};
+  justify-content: space-between;
   align-items: center;
-  padding: ${props => (props.isTabletPortraitUp ? "1em 0" : "0 1em")};
-  position: ${props => (props.isTabletPortraitUp ? "absolute" : "fixed")};
-  width: 100%;
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
   z-index: 1;
+  padding: 0 1em;
 
-  @media only screen and (min-width: ${PHONE_LANDSCAPE_UP}px) {
-    padding: 0 1.25em;
+  @media only screen and (min-width: ${BETWEEN_SMALL_DEVICES_TABLET_UP}px) {
+    padding: 1em 0;
+    width: 98%;
   }
 
   @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
-    padding: 0.875em 0;
+    width: 96%;
   }
 
-  @media only screen and (min-width: ${DESKTOP_UP}px) {
+  @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
     padding: 1.25em 0;
   }
 
@@ -58,6 +59,7 @@ const SiteHeader = () => {
     `(min-width: ${MIN_WIDTH_BREAKPOINTS[6]}px)`
   );
   const [activeLink, setActiveLink] = useState(window.location.pathname);
+  const [isToggled, toggleMenu] = useState(false);
 
   const style = useSpring({
     to: { transform: "translate3d(0, 0, 0)", opacity: "1" },
@@ -67,8 +69,22 @@ const SiteHeader = () => {
 
   const memoizedHandleLinkClick = useCallback(link => setActiveLink(link), []);
 
+  const openMenu = () => {
+    toggleMenu(true);
+    document.body.className += " unscrollable";
+  };
+
+  const closeMenu = () => {
+    toggleMenu(false);
+    document.body.className = document.body.className.replace(
+      /\bunscrollable\b/g,
+      ""
+    );
+  };
+
   useEffect(() => {
     window.onpopstate = () => {
+      closeMenu();
       memoizedHandleLinkClick(window.location.pathname);
     };
   });
@@ -84,7 +100,11 @@ const SiteHeader = () => {
           />
         </Fragment>
       ) : (
-        <MobileNavbar />
+        <MobileNavbar
+          isToggled={isToggled}
+          openMenu={openMenu}
+          closeMenu={closeMenu}
+        />
       )}
     </AnimatedHeader>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -421,6 +421,9 @@ strong {
 
 .unscrollable {
   overflow: hidden;
+  height: 100%;
+  width: 100%;
+  position: fixed;
 }
 
 .clearfix:after {


### PR DESCRIPTION
The site header and mobile menu now properly scale as the width of the browser is adjusted.

When the document body is unscrollable, it is now `position: fixed` to prevent scrolling on mobile. Previously, the body would not scroll only on desktop browsers.

![mobile_menu](https://user-images.githubusercontent.com/7979400/62816479-4b539200-baf6-11e9-9b31-231df670a4c1.png)
