### PR TITLE
Updated gh-pages version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "shortid": "^2.2.14"
   },
   "devDependencies": {
-    "gh-pages": "^2.0.1",
+    "gh-pages": "^2.1.1",
     "ngrok": "^3.2.4",
     "prettier": "^1.17.0",
     "serve": "^11.0.1"


### PR DESCRIPTION
Updated to version 2.1.1.

Fixes the following issue:

```
The "file" argument must be of type string. Received type undefined
```