### PR TITLE
Moved public URL to the basepath of the Router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -168,16 +168,17 @@ const App = () => {
                     <Router
                       location={state === "update" ? location : loc}
                       primary={false}
+                      basepath={process.env.PUBLIC_URL}
                     >
-                      <AsyncHomepage path={`${process.env.PUBLIC_URL}/`} />
+                      <AsyncHomepage path="/" />
                       <AsyncOurStory
-                        path={`${process.env.PUBLIC_URL}/our-story`}
+                        path="our-story"
                         baseFactor={baseFactor}
                         isGreaterThanTablet={isGreaterThanTablet}
                       />
-                      <AsyncWhenWhere path={`${process.env.PUBLIC_URL}/when-where`} />
-                      <AsyncBridesmaidsGroomsmen path={`${process.env.PUBLIC_URL}/bridesmaids-groomsmen`} />
-                      <AsyncRSVP path={`${process.env.PUBLIC_URL}/rsvp`}/>
+                      <AsyncWhenWhere path="when-where" />
+                      <AsyncBridesmaidsGroomsmen path="bridesmaids-groomsmen" />
+                      <AsyncRSVP path="rsvp" />
                     </Router>
                   </animated.div>
                 )}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -119,7 +119,7 @@ const Navbar = ({
               />
             ) : (
               <StyledLink
-                to={`${process.env.PUBLIC_URL}${item.link}`}
+                to={item.link}
                 onClick={() => handleLinkClick(item.link)}
                 isNavbarDark={isNavbarDark}
                 active={activeLink === item.link}


### PR DESCRIPTION
Removed the public URL from the router and links.

Router now has the prop: `basepath={process.env.PUBLIC_URL}`