### PR TITLE
Index - 404

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_RSVP_ENDPOINT=http://localhost:3001/rsvp

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "predeploy": "npm run build",
+    "predeploy": "npm run build && cp build/index.html build/404.html",
     "deploy": "gh-pages -d build",
     "serve": "serve -s build",
     "public": "ngrok http"


### PR DESCRIPTION
Copy `index.html` as `404.html` in `build` folder to ensure when a user visits a non-homepage URL, that it will direct them to the `404.html`, which is a copy of `index.html`. 