### PR TITLE
Fixed scrolling when going to desktop from mobile menu

### DIFF
--- a/src/components/SiteHeader.js
+++ b/src/components/SiteHeader.js
@@ -87,7 +87,11 @@ const SiteHeader = () => {
       closeMenu();
       memoizedHandleLinkClick(window.location.pathname);
     };
-  });
+
+    if (isTabletPortraitUp) {
+      closeMenu();
+    }
+  }, [isTabletPortraitUp]);
 
   return (
     <AnimatedHeader isTabletPortraitUp={isTabletPortraitUp} style={style}>


### PR DESCRIPTION
The document body is now scrollable when expanding the width past 640px when inside the mobile menu. Previously, the menu would close, but the ability to scroll would not be returned.