### PR TITLE
CircleCI Deployment - Master Branch Only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.14
+    filters:
+      branches:
+        only: master
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Added filter to CircleCI configuration to trigger build/deployment on the master branch.