### PR TITLE
Patch - Missing Album Progress Bar in Mobile

### DIFF
--- a/src/components/InfiniteCarousel.js
+++ b/src/components/InfiniteCarousel.js
@@ -104,7 +104,7 @@ const StyledCarouselNavItems = styled.ul``;
 
 const StyledInfiniteCarousel = styled.div`
   pointer-events: ${props => !props.isShifted && "none"};
-  overflow-x: hidden;
+  overflow-x: visible;
   position: absolute;
   right: 0;
   bottom: 0;
@@ -113,6 +113,7 @@ const StyledInfiniteCarousel = styled.div`
 
   @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
     top: 0;
+    overflow-x: hidden;
   }
 `;
 


### PR DESCRIPTION
Fixed missing progress bar for album in mobile.

What's currently in production:

![](https://www.dropbox.com/s/k73r82rnxukezuu/Screenshot%202019-08-13%2023.05.10.png?raw=1)