### PR TITLE
Disabled guest form field when user selects not attending

### DIFF
--- a/src/components/FormArea.js
+++ b/src/components/FormArea.js
@@ -20,6 +20,8 @@ const StyledFormArea = styled.div`
   float: ${props => props.float || "none"};
   width: 100%;
   margin-bottom: 2em;
+  opacity: ${props => (props.disabled ? "0.5" : "1")};
+  transition: opacity 0.2s ease;
 
   @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
     margin-bottom: 2.75em;
@@ -81,9 +83,10 @@ const FormArea = ({
   subLabelError,
   error,
   children,
-  className
+  className,
+  disabled
 }) => (
-  <StyledFormArea className={className} float={float}>
+  <StyledFormArea className={className} float={float} disabled={disabled}>
     <StyledLabel htmlFor={inputId}>
       {label}
       {subLabel ? (

--- a/src/components/Guest.js
+++ b/src/components/Guest.js
@@ -57,9 +57,9 @@ const StyledGuest = styled.div`
   }
 
   &:hover {
-    color: rgba(54, 63, 84, 1);
-    background-color: rgba(240, 240, 245, 1);
-    cursor: pointer;
+    color: ${props => !props.disabled && "rgba(54, 63, 84, 1)"};
+    background-color: ${props => !props.disabled && "rgba(240, 240, 245, 1)"};
+    cursor: ${props => (props.disabled ? "not-allowed" : "pointer")};
   }
 `;
 
@@ -88,7 +88,7 @@ class Guest extends Component {
 
   render() {
     const { mounted, removed } = this.state;
-    const { handleRemoveGuest, guestName, guestId } = this.props;
+    const { handleRemoveGuest, guestName, guestId, disabled } = this.props;
 
     return (
       <StyledGuest
@@ -100,7 +100,8 @@ class Guest extends Component {
             handleRemoveGuest(guestId);
           }
         }}
-        onClick={() => this.setState({ removed: true })}
+        onClick={() => !disabled && this.setState({ removed: true })}
+        disabled={disabled}
       >
         {guestName}
         <StyledRemoveButton>+</StyledRemoveButton>

--- a/src/components/GuestInput.js
+++ b/src/components/GuestInput.js
@@ -18,51 +18,46 @@ const StyledInputContainer = styled.div`
   margin-bottom: 0.67em;
   position: relative;
   display: flex;
+`;
 
-  ${props =>
-    props.disabled &&
-    `
-    &::after {
-      position: absolute;
-      content: "MAX ${props.maxGuests} GUESTS";
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background-color: rgba(250, 252, 254, 1);
-      border: 1px dashed rgba(220, 223, 226, 1);
-      border-radius: 0.25em;
-      text-align: center;
-      color: rgba(54, 63, 84, 0.4);
-      padding: 0 1em;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      transition: all 0.2s ease;
-      cursor: not-allowed;
-      font-size: 1rem;
+const StyledMaxGuestsOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(250, 252, 254, 1);
+  border: 1px dashed rgba(220, 223, 226, 1);
+  border-radius: 0.25em;
+  text-align: center;
+  color: rgba(54, 63, 84, 0.4);
+  padding: 0 1em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.2s ease;
+  cursor: not-allowed;
+  font-size: 1rem;
 
-      @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
-        font-size: 1.1rem;
-      }
+  @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
+    font-size: 1.1rem;
+  }
 
-      @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
-        font-size: 1.15rem;
-      }
+  @media only screen and (min-width: ${SMALL_DEVICES_LANDSCAPE_UP}px) {
+    font-size: 1.15rem;
+  }
 
-      @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
-        font-size: 1.2rem;
-      }
+  @media only screen and (min-width: ${TABLET_PORTRAIT_UP}px) {
+    font-size: 1.2rem;
+  }
 
-      @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
-        font-size: 1.25rem;
-      }
-    }
+  @media only screen and (min-width: ${TABLET_LANDSCAPE_UP}px) {
+    font-size: 1.25rem;
+  }
 
-    &:hover::after {
-      color: rgba(54, 63, 84, 0.7);
-    }
-  `}
+  &:hover {
+    color: rgba(54, 63, 84, 0.7);
+  }
 `;
 
 const StyledLabel = styled.label`
@@ -84,9 +79,9 @@ const StyledGuestInput = styled.input`
   padding: 0 0.5em;
   vertical-align: middle;
   outline: none;
-  opacity: ${props => (props.disabled ? "0" : "1")};
   appearance: none;
   font-size: 1.1rem;
+  cursor: ${props => (props.disabled ? "not-allowed" : "auto")};
 
   @media only screen and (min-width: ${POST_IPHONE6_PORTRAIT_UP}px) {
     font-size: 1.2rem;
@@ -136,7 +131,6 @@ const StyledAddButton = styled.button`
   border-radius: 0.25em;
   vertical-align: middle;
   transition: all 0.2s ease;
-  opacity: ${props => (props.disabled ? "0" : "1")};
   padding: 0.6em 1em;
   font-size: 1rem;
 
@@ -159,9 +153,9 @@ const StyledAddButton = styled.button`
 
   &:hover,
   &:focus {
-    background-color: rgba(176, 246, 172, 1);
-    color: rgba(21, 37, 64, 1);
-    cursor: pointer;
+    background-color: ${props => !props.disabled && "rgba(176, 246, 172, 1)"};
+    color: ${props => !props.disabled && "rgba(21, 37, 64, 1)"};
+    cursor: ${props => (props.disabled ? "not-allowed" : "pointer")};
   }
 `;
 
@@ -170,9 +164,10 @@ const GuestInput = ({
   disabled,
   error,
   setInputRef,
-  handleAddGuest
+  handleAddGuest,
+  atMax
 }) => (
-  <StyledInputContainer maxGuests={maxGuests} disabled={disabled}>
+  <StyledInputContainer>
     <StyledLabel>
       <StyledGuestInput
         placeholder="Guest name"
@@ -186,13 +181,20 @@ const GuestInput = ({
             }
           }
         }}
-        disabled={disabled}
+        disabled={disabled || atMax}
       />
       {error ? <StyledInputError>* {error}</StyledInputError> : null}
     </StyledLabel>
-    <StyledAddButton type="button" disabled={disabled} onClick={handleAddGuest}>
+    <StyledAddButton
+      type="button"
+      disabled={disabled || atMax}
+      onClick={handleAddGuest}
+    >
       ADD
     </StyledAddButton>
+    {atMax ? (
+      <StyledMaxGuestsOverlay>MAX {maxGuests} GUESTS</StyledMaxGuestsOverlay>
+    ) : null}
   </StyledInputContainer>
 );
 

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -54,7 +54,7 @@ class Guests extends Component {
   };
 
   render() {
-    const { guests, handleRemoveGuest, maxGuests } = this.props;
+    const { guests, handleRemoveGuest, maxGuests, disabled } = this.props;
     const { inputError } = this.state;
 
     return (
@@ -67,6 +67,7 @@ class Guests extends Component {
                 guestId={guest.id}
                 guestName={guest.name}
                 handleRemoveGuest={handleRemoveGuest}
+                disabled={disabled}
               />
             ))}
           </StyledGuestList>
@@ -75,8 +76,9 @@ class Guests extends Component {
           setInputRef={this.setInputRef}
           handleAddGuest={this.handleAddGuest}
           error={inputError}
-          disabled={guests.length >= maxGuests}
+          disabled={disabled}
           maxGuests={maxGuests}
+          atMax={guests.length >= maxGuests}
         />
       </StyledGuestContainer>
     );

--- a/src/views/RSVP.js
+++ b/src/views/RSVP.js
@@ -501,10 +501,9 @@ class RSVP extends Component {
       lastName: lastName.value,
       emailAddress: emailAddress.value,
       isAttending: this.state.isAttending,
-      guests: this.state.guests.reduce(
-        (acc, guest) => acc.concat([guest.name]),
-        []
-      ),
+      guests: this.state.isAttending
+        ? this.state.guests.reduce((acc, guest) => acc.concat([guest.name]), [])
+        : [],
       message: message.value.replace(/\s\s+/g, " ")
     };
     return formJson;
@@ -725,12 +724,13 @@ class RSVP extends Component {
                 </StyledRadioLabel>
               </StyledRadioContainer>
             </FormArea>
-            <FormArea label="GUESTS">
+            <FormArea label="GUESTS" disabled={isAttending === false}>
               <Guests
                 guests={guests}
                 handleAddGuest={this.handleAddGuest}
                 handleRemoveGuest={this.handleRemoveGuest}
                 maxGuests={maxGuests}
+                disabled={isAttending === false}
               />
             </FormArea>
             <FormArea


### PR DESCRIPTION
Previously, the user would still be able to add and remove guests even after selecting "no" for if they will attend.

Both the guest input and add button are now disabled when "no" is selected. The user will not be able to remove currently added guests unless "yes" is selected.

Guests are not removed in case the user selects "no" by accident.
When the form is submitted and "no" is selected, any guests that were added will not be sent.

![rsvp-guests-not attending](https://user-images.githubusercontent.com/7979400/63645971-bf399100-c6d7-11e9-944d-38a0f5f4eacf.png)
